### PR TITLE
Revert "fix: embedded wallet not fetching identity (#4003)"

### DIFF
--- a/packages/appkit/src/client/appkit.ts
+++ b/packages/appkit/src/client/appkit.ts
@@ -125,6 +125,7 @@ export class AppKit extends AppKitBaseClient {
        *  network to a non-smart account supported network resulting in a different address
        */
 
+      this.setCaipAddress(caipAddress, namespace)
       if (!HelpersUtil.isLowerCaseMatch(user.address, AccountController.state.address)) {
         this.syncIdentity({
           address: user.address,
@@ -132,7 +133,6 @@ export class AppKit extends AppKitBaseClient {
           chainNamespace: namespace
         })
       }
-      this.setCaipAddress(caipAddress, namespace)
 
       this.setUser({ ...(AccountController.state.user || {}), email: user.email }, namespace)
 


### PR DESCRIPTION
This reverts commit 7b928359b98bd26411f565e29e28e0b261e95ed3.

# Description

Please include a brief summary of the change.

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For Linear issues: Closes APKT-xxx
For GH issues: closes #...

# Showcase (Optional)

If there is a UI change include the screenshots with before and after state.
If new feature is being introduced, include the link to demo recording.

# Checklist

- [ ] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [ ] My changes generate no new warnings
- [ ] I have reviewed my own code
- [ ] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link

## Summary by Sourcery

Reverts the order of operations in the `syncIdentity` function. This change ensures that the CAIP address is set before comparing user addresses, which is necessary to avoid issues when switching networks.