### PR TITLE
feat: expose WC relay clientId in useAppKitWallets (#5608)

### DIFF
--- a/.changeset/fiery-carrots-grin.md
+++ b/.changeset/fiery-carrots-grin.md
@@ -1,0 +1,5 @@
+---
+'@reown/appkit-controllers': patch
+---
+
+Exposes WC clientId in useAppKitWallets

--- a/packages/controllers/exports/react.ts
+++ b/packages/controllers/exports/react.ts
@@ -12,6 +12,7 @@ import {
 import { AlertController } from '../src/controllers/AlertController.js'
 import { ApiController } from '../src/controllers/ApiController.js'
 import { AssetController } from '../src/controllers/AssetController.js'
+import { BlockchainApiController } from '../src/controllers/BlockchainApiController.js'
 import { ChainController } from '../src/controllers/ChainController.js'
 import { ConnectionController } from '../src/controllers/ConnectionController.js'
 import { ConnectorController } from '../src/controllers/ConnectorController.js'
@@ -422,6 +423,11 @@ export interface UseAppKitWalletsReturn {
    * Boolean that indicates if there was an error fetching the WalletConnect URI.
    */
   wcError: boolean
+
+  /**
+   * The WalletConnect relay client ID. Set after a WalletConnect connection is established.
+   */
+  wcClientId: string | null
 }
 
 /**
@@ -442,6 +448,7 @@ export function useAppKitWallets(): UseAppKitWalletsReturn {
     count
   } = useSnapshot(ApiController.state)
   const { initialized, connectingWallet } = useSnapshot(PublicStateController.state)
+  const { clientId: wcClientId } = useSnapshot(BlockchainApiController.state)
 
   // Alert if headless is not enabled
   useEffect(() => {
@@ -595,7 +602,8 @@ export function useAppKitWallets(): UseAppKitWalletsReturn {
       fetchWallets: () => Promise.resolve(),
       resetWcUri,
       resetConnectingWallet,
-      getWcUri: () => Promise.resolve()
+      getWcUri: () => Promise.resolve(),
+      wcClientId: null
     }
   }
 
@@ -617,6 +625,7 @@ export function useAppKitWallets(): UseAppKitWalletsReturn {
     fetchWallets,
     resetWcUri,
     resetConnectingWallet,
-    getWcUri
+    getWcUri,
+    wcClientId
   }
 }

--- a/packages/controllers/tests/hooks/react.test.ts
+++ b/packages/controllers/tests/hooks/react.test.ts
@@ -886,7 +886,8 @@ describe('useAppKitWallets', () => {
       resetWcUri: expect.any(Function),
       resetConnectingWallet: expect.any(Function),
       getWcUri: expect.any(Function),
-      wcError: false
+      wcError: false,
+      wcClientId: null
     })
   })
 
@@ -934,6 +935,9 @@ describe('useAppKitWallets', () => {
         initialized: true,
         connectingWallet: undefined
       })
+      .mockReturnValueOnce({
+        clientId: null
+      })
 
     vi.spyOn(ConnectUtil, 'getInitialWallets').mockReturnValue(mockWallets)
     vi.spyOn(ConnectUtil, 'getWalletConnectWallets').mockReturnValue(mockWcWallets)
@@ -974,6 +978,9 @@ describe('useAppKitWallets', () => {
         initialized: true,
         connectingWallet: mockWalletItem
       })
+      .mockReturnValueOnce({
+        clientId: 'relay-client-abc123'
+      })
 
     vi.spyOn(ConnectUtil, 'getInitialWallets').mockReturnValue([])
     vi.spyOn(ConnectUtil, 'getWalletConnectWallets').mockReturnValue([])
@@ -986,6 +993,7 @@ describe('useAppKitWallets', () => {
     expect(result.connectingWallet).toEqual(mockWalletItem)
     expect(result.page).toBe(2)
     expect(result.count).toBe(50)
+    expect(result.wcClientId).toBe('relay-client-abc123')
   })
 
   it('should fetch wallets without query', async () => {
@@ -1010,6 +1018,9 @@ describe('useAppKitWallets', () => {
       .mockReturnValueOnce({
         initialized: true,
         connectingWallet: undefined
+      })
+      .mockReturnValueOnce({
+        clientId: null
       })
 
     vi.spyOn(ConnectUtil, 'getInitialWallets').mockReturnValue([])
@@ -1051,6 +1062,9 @@ describe('useAppKitWallets', () => {
         initialized: true,
         connectingWallet: undefined
       })
+      .mockReturnValueOnce({
+        clientId: null
+      })
 
     vi.spyOn(ConnectUtil, 'getInitialWallets').mockReturnValue([])
     vi.spyOn(ConnectUtil, 'getWalletConnectWallets').mockReturnValue([])
@@ -1087,6 +1101,9 @@ describe('useAppKitWallets', () => {
       .mockReturnValueOnce({
         initialized: true,
         connectingWallet: undefined
+      })
+      .mockReturnValueOnce({
+        clientId: null
       })
 
     vi.spyOn(ConnectUtil, 'getInitialWallets').mockReturnValue([])
@@ -1125,6 +1142,9 @@ describe('useAppKitWallets', () => {
       .mockReturnValueOnce({
         initialized: true,
         connectingWallet: undefined
+      })
+      .mockReturnValueOnce({
+        clientId: null
       })
 
     vi.spyOn(ConnectUtil, 'getInitialWallets').mockReturnValue([])
@@ -1166,6 +1186,9 @@ describe('useAppKitWallets', () => {
         initialized: true,
         connectingWallet: undefined
       })
+      .mockReturnValueOnce({
+        clientId: null
+      })
 
     vi.spyOn(ConnectUtil, 'getInitialWallets').mockReturnValue([])
     vi.spyOn(ConnectUtil, 'getWalletConnectWallets').mockReturnValue([])
@@ -1201,6 +1224,9 @@ describe('useAppKitWallets', () => {
         initialized: true,
         connectingWallet: undefined
       })
+      .mockReturnValueOnce({
+        clientId: null
+      })
 
     vi.spyOn(ConnectUtil, 'getInitialWallets').mockReturnValue([])
     vi.spyOn(ConnectUtil, 'getWalletConnectWallets').mockReturnValue([])
@@ -1235,6 +1261,9 @@ describe('useAppKitWallets', () => {
       .mockReturnValueOnce({
         initialized: true,
         connectingWallet: undefined
+      })
+      .mockReturnValueOnce({
+        clientId: null
       })
 
     vi.spyOn(ConnectUtil, 'getInitialWallets').mockReturnValue([])
@@ -1277,6 +1306,9 @@ describe('useAppKitWallets', () => {
         initialized: true,
         connectingWallet: undefined
       })
+      .mockReturnValueOnce({
+        clientId: null
+      })
 
     vi.spyOn(ConnectUtil, 'getInitialWallets').mockReturnValue([])
     vi.spyOn(ConnectUtil, 'getWalletConnectWallets').mockReturnValue([])
@@ -1315,6 +1347,9 @@ describe('useAppKitWallets', () => {
       .mockReturnValueOnce({
         initialized: true,
         connectingWallet: undefined
+      })
+      .mockReturnValueOnce({
+        clientId: null
       })
 
     vi.spyOn(ConnectUtil, 'getInitialWallets').mockReturnValue([])
@@ -1361,6 +1396,9 @@ describe('useAppKitWallets', () => {
         initialized: true,
         connectingWallet: undefined
       })
+      .mockReturnValueOnce({
+        clientId: null
+      })
 
     vi.spyOn(ConnectUtil, 'getInitialWallets').mockReturnValue([])
     vi.spyOn(ConnectUtil, 'getWalletConnectWallets').mockReturnValue([])
@@ -1404,6 +1442,9 @@ describe('useAppKitWallets', () => {
         initialized: true,
         connectingWallet: undefined
       })
+      .mockReturnValueOnce({
+        clientId: null
+      })
 
     vi.spyOn(ConnectUtil, 'getInitialWallets').mockReturnValue([])
     vi.spyOn(ConnectUtil, 'getWalletConnectWallets').mockReturnValue([])
@@ -1439,6 +1480,9 @@ describe('useAppKitWallets', () => {
       .mockReturnValueOnce({
         initialized: true,
         connectingWallet: undefined
+      })
+      .mockReturnValueOnce({
+        clientId: null
       })
 
     vi.spyOn(ConnectUtil, 'getInitialWallets').mockReturnValue([])
@@ -1479,6 +1523,9 @@ describe('useAppKitWallets', () => {
         initialized: true,
         connectingWallet: undefined
       })
+      .mockReturnValueOnce({
+        clientId: null
+      })
 
     vi.spyOn(ConnectUtil, 'getInitialWallets').mockReturnValue([])
     vi.spyOn(ConnectUtil, 'getWalletConnectWallets').mockReturnValue([])
@@ -1511,6 +1558,9 @@ describe('useAppKitWallets', () => {
       .mockReturnValueOnce({
         initialized: true,
         connectingWallet: undefined
+      })
+      .mockReturnValueOnce({
+        clientId: null
       })
 
     vi.spyOn(ConnectUtil, 'getInitialWallets').mockReturnValue([])
@@ -1547,6 +1597,9 @@ describe('useAppKitWallets', () => {
         initialized: true,
         connectingWallet: undefined
       })
+      .mockReturnValueOnce({
+        clientId: null
+      })
 
     const mockSearchWalletItems = mockSearchWallets.map(w => ({
       ...mockWalletItem,
@@ -1580,6 +1633,9 @@ describe('useAppKitWallets', () => {
       .mockReturnValueOnce({
         initialized: true,
         connectingWallet: undefined
+      })
+      .mockReturnValueOnce({
+        clientId: null
       })
 
     vi.spyOn(ConnectUtil, 'getInitialWallets').mockReturnValue([])
@@ -1621,6 +1677,9 @@ describe('useAppKitWallets', () => {
       .mockReturnValueOnce({
         initialized: true,
         connectingWallet: undefined
+      })
+      .mockReturnValueOnce({
+        clientId: null
       })
 
     vi.spyOn(ConnectUtil, 'getInitialWallets').mockReturnValue([])


### PR DESCRIPTION
CI is a bit flaky, gh runners having issues for final test

# Description

Please include a brief summary of the change.

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For Linear issues: Closes APKT-xxx
For GH issues: closes #...

# Showcase (Optional)

If there is a UI change include the screenshots with before and after state.
If new feature is being introduced, include the link to demo recording.

# Checklist

- [ ] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [ ] My changes generate no new warnings
- [ ] I have reviewed my own code
- [x] I have filled out all required sections
- [x] I have tested my changes on the preview link
- [x] Approver of this PR confirms that the changes are tested on the preview link

## Summary by Sourcery

Expose the WalletConnect relay client ID through the useAppKitWallets React hook and update related tests and package metadata.

New Features:
- Expose wcClientId from BlockchainApiController via the useAppKitWallets hook return value to surface the WalletConnect relay client ID to consumers.

Tests:
- Extend useAppKitWallets tests to cover the new wcClientId behavior in both connected and non-connected scenarios.

Chores:
- Add a changeset entry to release a patch version of @reown/appkit-controllers for the new wcClientId exposure.