### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/clear_cache.yml
+++ b/.github/workflows/clear_cache.yml
@@ -5,6 +5,9 @@
 # This workflow helps with housekeeping the caches.
 # See https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#force-deleting-cache-entries
 name: Post-merge Cache Cleanup
+permissions:
+  contents: read
+  actions: write
 on:
   pull_request:
     types:


### PR DESCRIPTION
Potential fix for [https://github.com/Dargon789/appkit/security/code-scanning/2](https://github.com/Dargon789/appkit/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the workflow level to explicitly define the least privileges required. Based on the workflow's operations, it needs `contents: read` to access repository contents and `actions: write` to manage GitHub Actions caches. These permissions will be added to the root of the workflow file to apply to all jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

CI:
- Set workflow-level permissions to read repository contents and write GitHub Actions metadata for the post-merge cache cleanup job.